### PR TITLE
Add version banner to build artifacts - Issue #6

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,8 @@
   "version": "0.3.0",
   "homepage": "https://github.com/Squareknot/marionette.state",
   "authors": [
-    "ianmstew <ianmstew@gmail.com>"
+    "ianmstew <ianmstew@gmail.com>",
+    "yurkaninryan <yurkaninryan@gmail.com>"
   ],
   "description": "One-way data flow architecture for stateful components within a Backbone.Marionette app.",
   "main": "build/marionette.state.js",

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -17,6 +17,13 @@ const config = manifest.babelBoilerplateOptions;
 const mainFile = manifest.main;
 const destinationFolder = path.dirname(mainFile);
 const exportFileName = path.basename(mainFile, path.extname(mainFile));
+const banner = [
+  '/*',
+  ' * <%= manifest.name %> - <%= manifest.description %>',
+  ' * v<%= manifest.version %>',
+  ' */',
+  ''
+].join('\n');
 
 // Remove the built files
 gulp.task('clean', function (cb) {
@@ -54,7 +61,6 @@ createLintTask('lint-src', ['src/**/*.js']);
 createLintTask('lint-test', ['test/**/*.js']);
 
 // Build two versions of the library
-// TODO: Add versioned banner.
 gulp.task('build', ['lint-src', 'clean'], function (done) {
   esperanto.bundle({
     base:  'src',
@@ -75,10 +81,12 @@ gulp.task('build', ['lint-src', 'clean'], function (done) {
       .pipe($.plumber())
       .pipe($.sourcemaps.init({ loadMaps: true }))
       .pipe($.babel({ blacklist: ['useStrict'] }))
+      .pipe($.header(banner, { manifest : manifest }))
       .pipe($.sourcemaps.write('./', { addComment: false }))
       .pipe(gulp.dest(destinationFolder))
       .pipe($.filter(['*', '!**/*.js.map']))
       .pipe($.rename(exportFileName + '.min.js'))
+      .pipe($.header(banner, { manifest : manifest }))
       .pipe($.sourcemaps.init({ loadMaps: true }))
       .pipe($.uglify())
       .pipe($.sourcemaps.write('./'))

--- a/package.json
+++ b/package.json
@@ -37,6 +37,9 @@
     "email": "ianmstew@gmail.com",
     "web": "https://ianmstew.com"
   },
+  "contributors": [
+    { "name": "Ryan Yurkanin", "url": "http://ryanyurkan.in", "email":" yurkaninryan@gmail.com" }
+  ],
   "bugs": {
     "url": "https://github.com/Squareknot/marionette.state/issues"
   },
@@ -47,8 +50,8 @@
   "github": "https://github.com/Squareknot/marionette.state.git",
   "dependencies": {
     "backbone": "1.0.0 - 1.1.2",
-    "underscore": "1.4.4 - 1.6.0",
-    "backbone.marionette": "2.1.0 - 2.4.1"
+    "backbone.marionette": "2.1.0 - 2.4.1",
+    "underscore": "1.4.4 - 1.6.0"
   },
   "devDependencies": {
     "babel": "^5.0.0",
@@ -65,6 +68,7 @@
     "gulp-eslint": "^0.12.0",
     "gulp-file": "^0.2.0",
     "gulp-filter": "^2.0.0",
+    "gulp-header": "^1.7.1",
     "gulp-istanbul": "^0.6.0",
     "gulp-jscs": "^1.4.0",
     "gulp-livereload": "^3.4.0",


### PR DESCRIPTION
This pull request adds gulp-header to our pipeline.  Currently it only attaches the versioned banner to the not minified build artifacts, and also not to the sourcemaps.  Not sure if this is the expected behavior.
